### PR TITLE
CU-13qq29n_Bugfix-handle-discovery-errors 

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -15,6 +15,10 @@ module OmniAuth
       include OmniAuth::Strategy
       extend Forwardable
 
+      ERROR_MESSAGES = {
+        :discovery_failed => 'sso_discovery_failed',
+      }
+
       RESPONSE_TYPE_EXCEPTIONS = {
         'id_token' => { exception_class: OmniAuth::OpenIDConnect::MissingIdTokenError, key: :missing_id_token }.freeze,
         'code' => { exception_class: OmniAuth::OpenIDConnect::MissingCodeError, key: :missing_code }.freeze,
@@ -102,6 +106,13 @@ module OmniAuth
         @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(options.issuer)
       end
 
+      def construct_redirection_uri(error_message)
+        url = URI(options.post_logout_redirect_uri)
+        new_query_ar = URI.decode_www_form(url.query || '') << ['error', error_message]
+        url.query = URI.encode_www_form(new_query_ar)
+        url
+      end
+
       def request_phase
         if options.idp_configured
           options.issuer = issuer if options.issuer.to_s.empty?
@@ -110,6 +121,9 @@ module OmniAuth
         else
           redirect options.post_logout_redirect_uri
         end
+      rescue ::OpenIDConnect::Discovery::DiscoveryFailed
+        url = construct_redirection_uri ERROR_MESSAGES[:discovery_failed]
+        redirect url.to_s
       end
 
       def callback_phase
@@ -141,6 +155,9 @@ module OmniAuth
         fail!(:timeout, e)
       rescue ::SocketError => e
         fail!(:failed_to_connect, e)
+      rescue ::OpenIDConnect::Discovery::DiscoveryFailed
+        url = construct_redirection_uri ERROR_MESSAGES[:discovery_failed]
+        redirect url.to_s
       end
 
       def other_phase
@@ -150,6 +167,9 @@ module OmniAuth
           return redirect(end_session_uri) if end_session_uri
         end
         call_app!
+      rescue ::OpenIDConnect::Discovery::DiscoveryFailed
+        url = construct_redirection_uri ERROR_MESSAGES[:discovery_failed]
+        redirect url.to_s
       end
 
       def authorization_code

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -65,6 +65,7 @@ module OmniAuth
       option :pkce_challenge_algo, "S256" # plain unsupported
       option :pkce_challenge_length, 128
       option :idp_configured, false
+      option :error_redirect_uri
 
       def uid
         user_info.raw_attributes[options.uid_field.to_sym] || user_info.sub
@@ -107,7 +108,8 @@ module OmniAuth
       end
 
       def construct_redirection_uri(error_message)
-        url = URI(options.post_logout_redirect_uri)
+        url = options.error_redirect_uri || options.post_logout_redirect_uri
+        url = URI(url)
         new_query_ar = URI.decode_www_form(url.query || '') << ['error', error_message]
         url.query = URI.encode_www_form(new_query_ar)
         url

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -14,6 +14,9 @@ module OmniAuth
         expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
+        strategy.options.idp_configured = true
+        strategy.options.pkce_challenge_enabled = false
+
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase
       end
@@ -38,6 +41,23 @@ module OmniAuth
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.other_phase
+      end
+
+      def test_logout_phase_with_discovery_fails
+        expected_redirect = /localhost\?error=sso_discovery_failed/
+        strategy.options.client_options.host = 'example.com'
+        strategy.options.discovery = true
+        strategy.options.post_logout_redirect_uri = 'localhost'
+
+        issuer = stub('OpenIDConnect::Discovery::Issuer')
+        issuer.stubs(:issuer).returns('https://example.com/')
+        ::OpenIDConnect::Discovery::Provider
+          .stubs(:discover!)
+          .raises(::OpenIDConnect::Discovery::DiscoveryFailed.new())
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        request.stubs(:path_info).returns('/auth/openid_connect/logout')
         strategy.other_phase
       end
 
@@ -79,6 +99,8 @@ module OmniAuth
         expected_redirect = /^https:\/\/example\.com\/authorize\?claims_locales=es&client_id=1234&login_hint=john.doe%40example.com&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}&ui_locales=en$/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
+        strategy.options.idp_configured = true
+        strategy.options.pkce_challenge_enabled = false
         request.stubs(:params).returns('login_hint' => 'john.doe@example.com', 'ui_locales' => 'en', 'claims_locales' => 'es')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
@@ -89,6 +111,8 @@ module OmniAuth
         expected_redirect = /^https:\/\/example\.com\/authorization\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
+        strategy.options.idp_configured = true
+        strategy.options.pkce_challenge_enabled = false
 
         issuer = stub('OpenIDConnect::Discovery::Issuer')
         issuer.stubs(:issuer).returns('https://example.com/')
@@ -112,12 +136,33 @@ module OmniAuth
         assert_nil strategy.options.client_options.end_session_endpoint
       end
 
+      def test_request_phase_with_discovery_fails
+        
+        strategy.options.client_options.host = 'example.com'
+        strategy.options.discovery = true
+        strategy.options.pkce_challenge_enabled = false
+        strategy.options.idp_configured = true
+        strategy.options.post_logout_redirect_uri = 'localhost'
+
+        issuer = stub('OpenIDConnect::Discovery::Issuer')
+        issuer.stubs(:issuer).returns('https://example.com/')
+        ::OpenIDConnect::Discovery::Provider
+          .stubs(:discover!)
+          .raises(::OpenIDConnect::Discovery::DiscoveryFailed.new())
+        
+        expected_redirect = /localhost\?error=sso_discovery_failed/
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+      end
+
       def test_request_phase_with_response_mode
         expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&nonce=\w{32}&response_mode=form_post&response_type=id_token&scope=openid&state=\w{32}$/
         strategy.options.issuer = 'example.com'
         strategy.options.response_mode = 'form_post'
         strategy.options.response_type = 'id_token'
         strategy.options.client_options.host = 'example.com'
+        strategy.options.idp_configured = true
+        strategy.options.pkce_challenge_enabled = false
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase
@@ -129,6 +174,8 @@ module OmniAuth
         strategy.options.response_mode = 'form_post'
         strategy.options.response_type = :id_token
         strategy.options.client_options.host = 'example.com'
+        strategy.options.idp_configured = true
+        strategy.options.pkce_challenge_enabled = false
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase
@@ -262,6 +309,31 @@ module OmniAuth
         client.expects(:access_token!).at_least_once.returns(access_token)
         access_token.expects(:userinfo!).returns(user_info)
 
+        strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
+        strategy.callback_phase
+      end
+
+      def test_callback_phase_with_discovery_fail
+        code = SecureRandom.hex(16)
+        state = SecureRandom.hex(16)
+        nonce = SecureRandom.hex(16)
+        jwks = JSON::JWK::Set.new(JSON.parse(File.read('test/fixtures/jwks.json'))['keys'])
+
+        request.stubs(:params).returns('code' => code, 'state' => state)
+        request.stubs(:path_info).returns('')
+
+        strategy.options.client_options.host = 'example.com'
+        strategy.options.discovery = true
+        strategy.options.post_logout_redirect_uri = 'localhost'
+
+        issuer = stub('OpenIDConnect::Discovery::Issuer')
+        issuer.stubs(:issuer).returns('https://example.com/')
+        ::OpenIDConnect::Discovery::Provider
+          .stubs(:discover!)
+          .raises(::OpenIDConnect::Discovery::DiscoveryFailed.new())
+        expected_redirect = /localhost\?error=sso_discovery_failed/
+        
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
         strategy.callback_phase
       end
@@ -482,6 +554,7 @@ module OmniAuth
 
         expected_redirect = /&state=42/
         strategy.options.issuer = 'example.com'
+        strategy.options.idp_configured = true
         strategy.options.client_options.host = 'example.com'
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase
@@ -510,6 +583,7 @@ module OmniAuth
           env[:QUERY_STRING][:state] + env[:QUERY_STRING][:client_id]
         }
 
+        strategy.options.idp_configured = true
         expected_redirect = /&state=abc123/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'


### PR DESCRIPTION
Adding support to handle discovery error by redirecting to post-redirect-uri with error message as request param